### PR TITLE
device-diagnostics: replace references to resin-vars

### DIFF
--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -15,8 +15,14 @@ source /etc/profile
 # Set aside arguments, come back to them later
 current_args=( "$@" )
 set --
+# We still need to include resin-vars on legacy systems
+if [ -f /usr/sbin/resin-vars ]; then
 # shellcheck disable=SC1091
-source /usr/sbin/resin-vars
+  source /usr/sbin/resin-vars
+else
+# shellcheck disable=SC1091
+  source /usr/sbin/balena-config-vars
+fi
 # Restore arguments passed in originally
 set -- "${current_args[@]}"
 # shellcheck disable=SC1091

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -3,9 +3,14 @@ DIAGNOSE_VERSION=4.20.26
 # Don't run anything before this source as it sets PATH here
 # shellcheck disable=SC1091
 source /etc/profile
+# We still need to include resin-vars on legacy systems
+if [ -f /usr/sbin/resin-vars ]; then
 # shellcheck disable=SC1091
-source /usr/sbin/resin-vars
-
+  source /usr/sbin/resin-vars
+else
+# shellcheck disable=SC1091
+  source /usr/sbin/balena-config-vars
+fi
 # workaround for self-signed certs, waiting for https://github.com/balena-os/meta-balena/issues/1398
 TMPCRT=$(mktemp)
 echo "${BALENA_ROOT_CA}" | base64 -d > "${TMPCRT}"


### PR DESCRIPTION
Replace all references to the 'resin-vars' script with 'balena-config-vars' as it has been renamed.

This PR needs to be merged when https://github.com/balena-os/meta-balena/pull/2142 has been merged.

Change-type: patch
Changelog-entry: device-diagnostics: replace references to resin-vars
Signed-off-by: Mark Corbin <mark@balena.io>

### Hey there, appreciated contributor!

Have you taken a look at the [contribution guidelines](../CONTRIBUTING.md) for this project? To enable our CI to work correctly and version the releases of the project, you need to ensure your commit messages contain the required information [detailed here](../CONTRIBUTING.md). Thank you!
