### PR TITLE
Add diagnostics for boot performance

### DIFF
--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -77,6 +77,11 @@ commands=(
 	'journalctl --no-pager --no-hostname -n 1000 -at balenad'
 	'$ENG inspect \$($ENG ps --all --quiet | tr \"\\n\" \" \") | $filter_container_envs'
 
+	# Boot performance
+	'echo === BOOT ==='
+	'systemd-analyze'
+	'systemd-analyze critical-chain'
+
 	# HARDWARE specific commands
 	'echo === HARDWARE ==='
 	'cat /proc/cpuinfo'


### PR DESCRIPTION
Some users have applications that are sensitive to boot performance, and
diagnostics can help trace the cause of regressions in boot time, or
misbehaving services.

Add `systemd-analyze` and `systemd-analyze critical-chain` to
diagnostics to get an overall boot time, as well as a breakdown by unit.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>

Links to: https://github.com/balena-io-modules/device-diagnostics/issues/271
