### PR TITLE
Check for IPv6 DNS's without matching dates

### DIFF
--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -97,7 +97,7 @@ function test_upstream_dns()
 {
 	# force dnsmasq to print statistics to journal to read them back
 	systemctl kill -s USR1 dnsmasq
-	for i in $(journalctl _SYSTEMD_INVOCATION_ID="$(systemctl show -p InvocationID --value dnsmasq.service)" | awk '{print $NF}' | egrep -o '([12]?[0-9]?[0-9]\.[12]?[0-9]?[0-9]\.[12]?[0-9]?[0-9]\.[12]?[0-9]?[0-9])|(([a-f0-9:]+:+)+[a-f0-9]+)' | sort -u); do
+	for i in $(journalctl _SYSTEMD_INVOCATION_ID="$(systemctl show -p InvocationID --value dnsmasq.service)" | tail -n +2 | awk '{$1=$2=$3=""; print $0}' | egrep -o '([12]?[0-9]?[0-9]\.[12]?[0-9]?[0-9]\.[12]?[0-9]?[0-9]\.[12]?[0-9]?[0-9])|(([a-f0-9:]+:+)+[a-f0-9]+)' | sort -u); do
 		# shellcheck disable=SC2001
 		for j in "${external_fqdn}" "$(echo "${API_ENDPOINT}" | sed -e 's@^https*://@@')"; do
 			if ! nslookup "${j}" "${i}" > /dev/null 2>&1; then


### PR DESCRIPTION
skip first line and first 3 columns to avoid matching date instead of IPv6 addresses

In order to avoid matching dates when matching IPv6 addresses, I only matched the last field.

Unfortunately, dnsmasq doesn't always print the DNS as the last field per https://github.com/balena-io-modules/device-diagnostics/pull/286#issuecomment-918132277

Instead, simply skip the first line and the first 3 columns which contain the log date.

Change-type: patch
