### PR TITLE
Fix IPv6 address (typo) used in the test_ipv6_stack check

### DIFF
--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -44,8 +44,8 @@ TIMEOUT_CMD="timeout --kill-after=$(( TIMEOUT * 2 )) ${TIMEOUT}"
 mountpoint="/var/lib/${ENG}"
 
 external_fqdn="0.resinio.pool.ntp.org"
-IPV4_ADDRESS="1.1.1.1"
-IPV6_ADDRESS="2606:4700:4700:6400"
+IPV4_ADDRESS="1.1.1.1" # https://1.1.1.1/dns/
+IPV6_ADDRESS="2606:4700:4700::6400" # https://developers.cloudflare.com/1.1.1.1/ipv6-networks
 IPV4_ENDPOINT="ipv4.google.com"
 IPV6_ENDPOINT="ipv6.google.com"
 


### PR DESCRIPTION
Before this PR, the `test_ipv6_stack` check was being effectively bypassed because the `ip -6 route get` command was always failing because of a typo in the IPv6 address, which was interpreted by the script as an unavailable IPv6 stack.

Change-type: patch
Connects-to: #292
Connects-to: #294