### PR TITLE
Fix Engine network diagnostic

### DIFF
--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -77,7 +77,7 @@ commands=(
 	'journalctl --no-pager --no-hostname -n 200 -a -u $ENG'
 	'journalctl --no-pager --no-hostname -n 1000 -at balenad'
 	'$ENG inspect \$($ENG ps --all --quiet | tr \"\\n\" \" \") | $filter_container_envs'
-	'$ENG network inspect \$($ENG ps --quiet | tr \"\\n\" \" \")'
+	'$ENG network inspect \$($ENG network ls --quiet | tr \"\\n\" \" \")'
 	'test -f /mnt/state/balena-engine-storage-migration.log && cat /mnt/state/balena-engine-storage-migration.log'
 
 	# Boot performance


### PR DESCRIPTION
Diagnostic executions are failing with

```
--- balena network inspect $(balena ps --quiet | tr "\n" " ") ---

Error: No such network: ef3a43ba55d4
Error: No such network: af338f332384
Error: No such network: 8eef54236371
```

We were passing container IDs to `balena network inspect`. This fixes the command to pass network IDs, as expected.
